### PR TITLE
Feat: Deployer label and inspect CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,19 +148,18 @@ When deployer updates the image of a service, it also sets a label on the servic
 
 ```json
 {
-  "date": "2021-09-05T21:31:32.000Z", // "YYYY-MM-DDTHH:MM:SS.MMMZ
+  "date": "2021-09-05T21:31:32.000Z",
   "deployerVersion": "2.2.0",
-  "name": "deployer", // from deployer config. See deployer config CLI
-  "computerUsername": "Vasilis", // User logged on the computer when the command was ran
-  "deviceName": "LAPTOP-SD9J03UG", // as seen in PC's information
-  // OS details
+  "name": "deployer",
+  "computerUsername": "Vasilis",
+  "deviceName": "LAPTOP-SD9J03UG",
   "operatingSystem": {
     "type": "Windows_NT",
     "platform": "win32",
     "architecture": "x64",
     "release": "10.0.19043"
   },
-  "image": "deployer/hello-world1:latest" // image used to update the service during `up` command
+  "image": "deployer/hello-world1:latest"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,7 @@
 <br>
 <br>
 
-[![package][package-version]][package-url]
-
-<!-- <p align="center">
-  <a href="https://github.com/backslashbuild/deployer">
-    <img src="https://img.shields.io/github/package-json/v/backslashbuild/deployer" alt="Deployer version." />
-  </a>
-</p> -->
+[![package-version][package-version-img]][package-version-url]
 
 # Description
 
@@ -66,14 +60,15 @@ services:
 
 ## Commands
 
+- [Config](#config)
+  - [Reset](#config-reset)
+  - [Set](#config-set)
+  - [Unset](#config-unset)
+- [Inspect](#inspect)
 - [Registry](#registry)
   - [Start](#registry-start)
   - [Stop](#registry-stop)
 - [Up](#up)
-- [Config](#config)
-  - [Set](#config-set)
-  - [Unset](#config-unset)
-  - [Reset](#config-reset)
 
 ## Global options
 
@@ -85,6 +80,97 @@ services:
     --help      - Show help.
     --version   - Show version number.
 ```
+
+---
+
+## <a name="config"></a>Config
+
+### Description
+
+Deployer uses global configuration, stored at `~/.deployer/config.json`. Deployer comes with a default set of values configuration all of which can be changed using `deployer config set` and can be reset to default using `deployer config unset`. The config can be reset to default using `deployer config reset`.
+
+### Default config file
+
+```json
+{
+  "name": "deployer",
+  "loglevel": "INFO"
+}
+```
+
+### Dictionary
+
+- "**name**": A string that may contain alphanumeric characters and "-" which is used when deployer tags images. It is advised that a meaningful `name` is set to enable communication in a team environment.
+- "**loglevel**" A numerical value between 0-7 or a string representing a log level. Available options are: `OFF`, `FATAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG`, `TRACE`, `ALL`.
+
+### Commands
+
+### <a name="config-reset"></a>`deployer config reset`
+
+#### Description
+
+Resets the deployer config to default values.
+
+### <a name="config-set"></a>`deployer config set <key> <value>`
+
+#### Description
+
+Updates the deployer config `<key>` to provided `<value>`.
+
+#### Arguments
+
+```
+key   - The key of the config to be updated
+value - The value to be stored in the key
+```
+
+### <a name="config-unset"></a>`deployer config unset <key>`
+
+#### Description
+
+Resets the deployer config `<key>`.
+
+#### Arguments
+
+```
+key - The key of the config to be reset
+```
+
+---
+
+## <a name="inspect"></a>Inspect
+
+### Description
+
+When deployer updates the image of a service, it also sets a label on the service with metadata delated to the deploy in a stringified JSON format. Running `docker inspect` prints the metadata stored in the service label.
+
+### Deployer label contents
+
+```json
+{
+  "date": "2021-09-05T21:31:32.000Z", // "YYYY-MM-DDTHH:MM:SS.MMMZ
+  "deployerVersion": "2.2.0",
+  "name": "deployer", // from deployer config. See deployer config CLI
+  "computerUsername": "Vasilis", // User logged on the computer when the command was ran
+  "deviceName": "LAPTOP-SD9J03UG", // as seen in PC's information
+  // OS details
+  "operatingSystem": {
+    "type": "Windows_NT",
+    "platform": "win32",
+    "architecture": "x64",
+    "release": "10.0.19043"
+  },
+  "image": "deployer/hello-world1:latest" // image used to update the service during `up` command
+}
+```
+
+### Commands
+
+### `deployer inspect <host> <service>`
+
+#### Description
+
+Inspects deployer metadata of remote service.
 
 ---
 
@@ -150,58 +236,5 @@ services - Additional deployer.yaml keys to be deployed in parallel
 
 ---
 
-## <a name="config"></a>Config
-
-### Description
-
-Deployer uses global configuration, stored at `~/.deployer/config.json`. Deployer comes with a default set of values configuration all of which can be changed using `deployer config set` and can be reset to default using `deployer config unset`. The config can be reset to default using `deployer config reset`.
-
-### Default config file
-
-```json
-{
-  "name": "deployer",
-  "loglevel": "INFO"
-}
-```
-
-### Dictionary
-
-- "**name**": A string that may contain alphanumeric characters and "-" which is used when deployer tags images. It is advised that a meaningful `name` is set to enable communication in a team environment.
-- "**loglevel**" A numerical value between 0-7 or a string representing a log level. Available options are: `OFF`, `FATAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG`, `TRACE`, `ALL`.
-
-### Commands
-
-### <a name="config-set"></a>`deployer config set <key> <value>`
-
-#### Description
-
-Updates the deployer config `<key>` to provided `<value>`.
-
-#### Arguments
-
-```
-key   - The key of the config to be updated
-value - The value to be stored in the key
-```
-
-### <a name="config-unset"></a>`deployer config unset <key>`
-
-#### Description
-
-Resets the deployer config `<key>`.
-
-#### Arguments
-
-```
-key - The key of the config to be reset
-```
-
-### <a name="config-reset"></a>`deployer config reset`
-
-#### Description
-
-Resets the deployer config to default values.
-
-[package-url]: https://github.com/backslashbuild/deployer
-[package-version]: https://img.shields.io/github/package-json/v/backslashbuild/deployer
+[package-version-url]: https://github.com/backslashbuild/deployer
+[package-version-img]: https://img.shields.io/github/package-json/v/backslashbuild/deployer

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ key - The key of the config to be reset
 
 ### Description
 
-When deployer updates the image of a service, it also sets a label on the service with metadata delated to the deploy in a stringified JSON format. Running `docker inspect` prints the metadata stored in the service label.
+When deployer updates the image of a service, it also sets a label on the service with metadata related to the deploy in a stringified JSON format. Running `deployer inspect` prints the metadata stored in the service label.
 
 ### Deployer label contents
 

--- a/bin/cmds/inspect.js
+++ b/bin/cmds/inspect.js
@@ -1,0 +1,44 @@
+const { getServiceLabels, getServiceImage } = require("../utils/dockerUtils");
+const { formatter, logger } = require("../utils/textUtils");
+
+exports.command = "inspect <host> <service>";
+exports.desc = "Inspect deployer metadata of remote service.";
+exports.builder = function (yargs) {};
+exports.handler = function (argv) {
+  const { service, host } = argv;
+  logger.trace("deployer inspect called.", { host, service });
+
+  logger.info(`Fetching ${formatter.info(service)} labels from ${formatter.info(host)}...`);
+  const serviceLabelsResult = getServiceLabels(service, host);
+  logger.trace("Fetched service labels.", { ...serviceLabelsResult });
+
+  if (typeof serviceLabelsResult === "string") {
+    throw new Error(serviceLabelsResult);
+  }
+
+  if (!serviceLabelsResult.deployer) {
+    throw new Error("Deployer label not found.");
+  }
+
+  let deployerMetadata;
+  try {
+    logger.trace("JSON parsing deployer label.");
+    deployerMetadata = JSON.parse(serviceLabelsResult.deployer);
+    logger.trace("JSON parsed deployer label.", deployerMetadata);
+  } catch (e) {
+    logger.debug(e);
+    throw new Error(
+      `Malformed deployer label, content cannot be JSON parsed: ${serviceLabelsResult.deployer}`
+    );
+  }
+
+  logger.trace("Fetching remote service current image name");
+  const imageName = getServiceImage(service, host);
+  logger.trace("Fetched remote service current image name", { imageName });
+  const metaImageName = deployerMetadata.image;
+
+  logger.info(formatter.success(deployerMetadata));
+  if (imageName !== metaImageName) {
+    logger.warn(formatter.warning("Deployer metadata does not match currently deployed image."));
+  }
+};

--- a/bin/services/middleware/checkForUpdatesMiddleware.js
+++ b/bin/services/middleware/checkForUpdatesMiddleware.js
@@ -2,7 +2,8 @@ const fetch = require("node-fetch");
 const localPackageJson = require("../../../package.json");
 const { logger, formatter } = require("../../utils/textUtils");
 const YAML = require("yamljs");
-
+const fs = require("fs");
+const path = require("path");
 /**
  * @description Fetches the patch-notes.yml of the master branch from Deployer's repository and parses its contents into an object.
  * @returns {object} Parsed patch-notes.yml from remote.
@@ -78,6 +79,18 @@ async function printUpdates(localVersion, printFunc) {
   );
   updates.forEach((version) => {
     printPatchNotes(version, remotePatchNotes, printFunc);
+  });
+}
+
+/**
+ * To be used during development to preview patch notes.
+ */
+function previewPatchnotes() {
+  let localPatchNotes = YAML.parse(
+    fs.readFileSync(path.join(__dirname, "../../../patch-notes.yml"), "utf8")
+  );
+  Object.keys(localPatchNotes).forEach((version) => {
+    printPatchNotes(version, localPatchNotes, logger.info);
   });
 }
 

--- a/bin/utils/configUtils.js
+++ b/bin/utils/configUtils.js
@@ -1,5 +1,6 @@
 const os = require("os");
 const path = require("path");
+const packageJson = require("../../package.json");
 
 const deployerDirectory = path.resolve(os.homedir(), ".deployer");
 const configFileName = "config.json";
@@ -9,4 +10,5 @@ module.exports = {
   deployerDirectory,
   configFileName,
   deployerConfigFilePath,
+  deployerVersion: packageJson.version,
 };

--- a/bin/utils/textUtils/formatter.js
+++ b/bin/utils/textUtils/formatter.js
@@ -46,6 +46,15 @@ function warning(text) {
 }
 
 /**
+ * @description Colours the text magenta.
+ * @param {string} text - Text to be coloured.
+ * @returns {string} Magenta text.
+ */
+function debug(text) {
+  return colors.magenta(text);
+}
+
+/**
  * @description Encloses given text in a box.
  * @param {string} text - Text to be enclosed in a box.
  * @returns {string} Text enclosed in a box.
@@ -84,6 +93,7 @@ const formatter = {
   error,
   bold,
   warning,
+  debug,
   box,
 };
 

--- a/bin/utils/textUtils/logger.js
+++ b/bin/utils/textUtils/logger.js
@@ -1,74 +1,101 @@
-const loglevels = { OFF: 0, FATAL: 1, ERROR: 2, WARN: 3, INFO: 4, DEBUG: 5, TRACE: 6, ALL: 7 };
+const util = require("util");
+const formatter = require("./formatter");
 
 /**
- * @description Logs passed text, if LOG_LEVEL is greater or equal to fatal (1)
- * @param {string} text - Text to be logged.
+ * Enum for loglevel values.
+ * @enum {number}
  */
-function fatal(text) {
-  if (!isLevelSilent(loglevels.FATAL)) {
-    console.error(text);
-  }
-}
+var loglevels = { OFF: 0, FATAL: 1, ERROR: 2, WARN: 3, INFO: 4, DEBUG: 5, TRACE: 6, ALL: 7 };
 
 /**
- * @description Logs passed text, if LOG_LEVEL is higher or equal to error (2)
- * @param {string} text - Text to be logged.
- */
-function error(text) {
-  if (!isLevelSilent(loglevels.ERROR)) {
-    console.error(text);
-  }
-}
-
-/**
- * @description Logs passed text, if LOG_LEVEL is higher or equal to warn (3)
- * @param {string} text - Text to be logged.
- */
-function warn(text) {
-  if (!isLevelSilent(loglevels.WARN)) {
-    console.error(text);
-  }
-}
-
-/**
- * @description Logs passed text, if LOG_LEVEL is higher or equal to info (4)
- * @param {string} text - Text to be logged.
- */
-function info(text) {
-  if (!isLevelSilent(loglevels.INFO)) {
-    console.log(text);
-  }
-}
-
-/**
- * @description Logs passed text, if LOG_LEVEL is higher or equal to debug (5)
- * @param {string} text - Text to be logged.
- */
-function debug(text) {
-  if (!isLevelSilent(loglevels.DEBUG)) {
-    console.log(text);
-  }
-}
-
-/**
- * @description Logs passed text, if LOG_LEVEL is higher or equal to trace (6)
- * @param {string} text - Text to be logged.
- */
-function trace(text) {
-  if (!isLevelSilent(loglevels.TRACE)) {
-    console.log(text);
-  }
-}
-
-/**
- * @description Returns whether the --quiet flag was set as a command argument.
- * @returns true if command is running in quiet mode.
+ * @description Asserts whether given loglevel should or should not log.
+ * @param {loglevels} loglevel - The loglevel to assert whether it should be logging or not.
+ * @returns true if given log level should not log.
  */
 function isLevelSilent(loglevel) {
   if (!process.env.LOG_LEVEL) {
     return loglevels.FATAL < loglevel;
   }
   return process.env.LOG_LEVEL < loglevel;
+}
+
+/**
+ * @description Asserts whether the command is running in debug mode or not.
+ * @returns {boolean} True if the loglevel of the command is loglevels.DEBUG (5) or higher.
+ */
+function isDebugMode() {
+  return !isLevelSilent(loglevels.DEBUG);
+}
+
+/**
+ * @description Takes a list of strings and logs them using the <printFunc> if the <loglevel> provided is not silenced.
+ *              For flags higher or equal to loglevels.DEBUG (5) additional formatting is added.
+ * @param {Array<string>} textList - The array of strings to be logged
+ * @param {loglevels} loglevel - The loglevel at which the text should be printed.
+ * @param {(string)=>void} printFunc
+ */
+function log(textList, loglevel, printFunc) {
+  if (!isLevelSilent(loglevel)) {
+    if (isDebugMode()) {
+      printFunc(
+        formatter.debug(
+          `[${Object.keys(loglevels).find((level) => loglevels[level] === loglevel)}]`
+        )
+      );
+    }
+    textList.forEach((line) => {
+      printFunc(`${typeof line === "object" ? util.inspect(line, { depth: null }) : line}`);
+    });
+    isDebugMode() && printFunc("");
+  }
+}
+
+/**
+ * @description Logs passed text, if LOG_LEVEL is greater or equal to fatal (1)
+ * @param {Array<string>} textList - Text to be logged.
+ */
+function fatal(...textList) {
+  log(textList, loglevels.FATAL, console.error);
+}
+
+/**
+ * @description Logs passed text, if LOG_LEVEL is higher or equal to error (2)
+ * @param {Array<string>} textList - Text to be logged.
+ */
+function error(...textList) {
+  log(textList, loglevels.ERROR, console.error);
+}
+
+/**
+ * @description Logs passed text, if LOG_LEVEL is higher or equal to warn (3)
+ * @param {Array<string>} textList - Text to be logged.
+ */
+function warn(...textList) {
+  log(textList, loglevels.WARN, console.error);
+}
+
+/**
+ * @description Logs passed text, if LOG_LEVEL is higher or equal to info (4)
+ * @param {Array<string>} textList - Text to be logged.
+ */
+function info(...textList) {
+  log(textList, loglevels.INFO, console.log);
+}
+
+/**
+ * @description Logs passed text, if LOG_LEVEL is higher or equal to debug (5)
+ * @param {Array<string>} textList - Text to be logged.
+ */
+function debug(...textList) {
+  log(textList, loglevels.DEBUG, console.log);
+}
+
+/**
+ * @description Logs passed text, if LOG_LEVEL is higher or equal to trace (6)
+ * @param {Array<string>} textList - Text to be logged.
+ */
+function trace(...textList) {
+  log(textList, loglevels.TRACE, console.log);
 }
 
 const logger = {

--- a/command.js
+++ b/command.js
@@ -62,11 +62,13 @@ yargs
   .help()
   .group(["q", "l", "help", "version"], "Global options:")
   .fail((msg, e, yargs) => {
-    logger.fatal("");
-    logger.fatal(msg);
+    // The below should've been <msg> but it only does when the exception is thrown within the builder of the command,
+    // doesn't work for handler. The the regex is a workaround.
+    logger.fatal(formatter.error(/Error: (.*)/g.exec(e.toString())[1]));
     logger.debug(e);
-    logger.info("");
-    yargs.showHelp((s) => logger.info(s));
+    logger.info(
+      "\nFor help with the command run it with the `--help` flag, or visit the documentation."
+    );
     exit(1);
   })
   .wrap(90).argv;

--- a/command.js
+++ b/command.js
@@ -62,9 +62,19 @@ yargs
   .help()
   .group(["q", "l", "help", "version"], "Global options:")
   .fail((msg, e, yargs) => {
-    // The below should've been <msg> but it only does when the exception is thrown within the builder of the command,
-    // doesn't work for handler. The the regex is a workaround.
-    logger.fatal(formatter.error(/Error: (.*)/g.exec(e.toString())[1]));
+    /* 
+      Yargs does not consistently put the error message into <msg> so we have to extract it from the error ourselves
+      `e` will look like this:  
+          
+      Error: <ERROR_MESSAGE>
+        stacktrace line 1
+        stacktrace line 2
+
+      e.toString() returns "Error: <ERROR_MESSAGE>"
+    */
+    const errorMessage = /Error: (.*)/g.exec(e.toString())[1];
+
+    logger.fatal(formatter.error(errorMessage));
     logger.debug(e);
     logger.info(
       "\nFor help with the command run it with the `--help` flag, or visit the documentation."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "deployer",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -302,11 +302,6 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
       "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
-    },
-    "node-gzip": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/node-gzip/-/node-gzip-1.1.2.tgz",
-      "integrity": "sha512-ZB6zWpfZHGtxZnPMrJSKHVPrRjURoUzaDbLFj3VO70mpLTW5np96vXyHwft4Id0o+PYIzgDkBUjIzaNHhQ8srw=="
     },
     "once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deployer",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "description": "Builds specified docker image and deploys to remote host.",
   "repository": "https://github.com/backslashbuild/deployer",
   "main": "command.js",
@@ -13,7 +13,6 @@
     "cosmiconfig": "^7.0.0",
     "cross-spawn": "^7.0.3",
     "node-fetch": "^2.6.1",
-    "node-gzip": "^1.1.2",
     "shelljs": "^0.8.4",
     "yamljs": "^0.3.0",
     "yargs": "^17.1.1"

--- a/patch-notes.yml
+++ b/patch-notes.yml
@@ -64,3 +64,8 @@
   date: 02-09-2021
   notes:
   - note: Logs patch notes of available updates.
+2.2.0:
+  date: 05-09-2021
+  notes: 
+    - note: Upon deploying using `deployer up` a label is added to the targetted service containing deployment metadata.
+    - note: Adds `inspect` CLI. This command fetches the metadata stored in the services and logs them.


### PR DESCRIPTION
- Adds `inspect` CLI which fetches the "deployer" label from the remote service and prints it
- `deployer up` now also sets a label on the service with metadata about the deploy.
- Orders the documentation in README.md to alphabetical order of contents.
- Adds `inspect` documentation to README.md.
- Small refactor of logger to allow multiple logs in single function call.