### PR TITLE
Check for updates config flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,14 +94,16 @@ Deployer uses global configuration, stored at `~/.deployer/config.json`. Deploye
 ```json
 {
   "name": "deployer",
-  "loglevel": "INFO"
+  "logLevel": "INFO",
+  "checkForUpdates": true
 }
 ```
 
 ### Dictionary
 
 - "**name**": A string that may contain alphanumeric characters and "-" which is used when deployer tags images. It is advised that a meaningful `name` is set to enable communication in a team environment.
-- "**loglevel**" A numerical value between 0-7 or a string representing a log level. Available options are: `OFF`, `FATAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG`, `TRACE`, `ALL`.
+- "**logLevel**" A numerical value between 0-7 or a string representing a log level. Available options are: `OFF`, `FATAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG`, `TRACE`, `ALL`.
+- "**checkForUpdates**" A flag to choose whether deployer should check for updates.
 
 ### Commands
 

--- a/README.md
+++ b/README.md
@@ -73,12 +73,13 @@ services:
 ## Global options
 
 ```
--q, --quiet     - Suppresses verbose output. Sets log-level to 1.
--l, --log-level - Sets the log-level to provided level. Accepts numerical value between
-                 0-7 or one of the choices.
-                 [choices: "OFF", "FATAL", "ERROR", "WARN", "INFO", "DEBUG", "TRACE", "ALL"]
-    --help      - Show help.
-    --version   - Show version number.
+-q, --quiet           Suppresses verbose output. Sets log-level to 1.
+-l, --log-level       Sets the log-level to provided level. Accepts numerical value between
+                      0-7 or one of the choices.
+                [choices: "OFF", "FATAL", "ERROR", "WARN", "INFO", "DEBUG", "TRACE", "ALL"]
+    --help            Show help.
+    --version         Show version number.
+    --check-updates   Sets whether the command should check for updates before executing.
 ```
 
 ---

--- a/bin/cmds/config_cmds/reset.js
+++ b/bin/cmds/config_cmds/reset.js
@@ -1,7 +1,6 @@
 const { logger, formatter } = require("../../utils/textUtils");
 const fs = require("fs");
-const defaultConfig = require("../../res/defaultConfig.json");
-const { deployerConfigFilePath } = require("../../utils/configUtils");
+const { deployerConfigFilePath, defaultConfig } = require("../../utils/configUtils");
 
 exports.command = "reset";
 exports.desc = "Reverts all config keys to default values.";

--- a/bin/cmds/config_cmds/set.js
+++ b/bin/cmds/config_cmds/set.js
@@ -2,22 +2,20 @@ const { logger, formatter } = require("../../utils/textUtils");
 const fs = require("fs");
 const defaultConfig = require("../../res/defaultConfig.json");
 const { deployerConfigFilePath } = require("../../utils/configUtils");
+const {
+  convertInputToBoolean,
+  convertInputToLogLevel,
+  convertInputToDeployerConfigKey,
+} = require("../../utils/inputUtils");
 
 exports.command = "set <key> <value>";
 exports.desc = "Sets the key and value pair in the config.";
 exports.builder = (yargs) => {
   yargs.check((argv) => {
-    const acceptableKeys = Object.keys(defaultConfig).map((element) => element.toLowerCase());
-    if (!acceptableKeys.includes(argv.key.toLowerCase())) {
-      throw new Error(
-        formatter.error(
-          `Key ${argv.key} is not supported. Acceptable keys are:\n${acceptableKeys.join(", ")}`
-        )
-      );
-    }
+    const key = convertInputToDeployerConfigKey(argv.key);
 
     //Coerce user input to correct config
-    switch (argv.key.toLowerCase()) {
+    switch (key.toLowerCase()) {
       case "name":
         var validCharset = /^[a-zA-Z0-9-]+$/;
         if (!validCharset.test(argv.value)) {
@@ -28,44 +26,26 @@ exports.builder = (yargs) => {
         argv.value = argv.value.toLowerCase();
         break;
       case "loglevel":
-        //if loglevel is given as a number, clamp it to accepted range and match correct loglevel name
-        if (typeof argv.value === "number") {
-          if (argv.value < logger.loglevels.OFF) {
-            argv.value = logger.loglevels.OFF;
-          } else if (argv.value > logger.loglevels.ALL) {
-            argv.value = logger.loglevels.ALL;
-          }
-          argv.value = Object.keys(logger.loglevels).find(
-            (level) => logger.loglevels[level] === argv.value
-          );
-        }
-        //if loglevel is given as a name, format it correclty to check if it is a valid loglevel name
-        else {
-          if (!Object.keys(logger.loglevels).includes(argv.value.toString().toUpperCase())) {
-            throw new Error(
-              formatter.error(
-                `Log level can only be between 0-7 or one of the option: ${Object.keys(
-                  logger.loglevels
-                ).join(", ")}`
-              )
-            );
-          } else {
-            argv.value = argv.value.toString().toUpperCase();
-          }
-        }
+        argv.value = convertInputToLogLevel(argv.value);
+        break;
+      case "checkforupdates":
+        argv.value = convertInputToBoolean(argv.value);
+        break;
     }
     return true;
   });
 };
 exports.handler = function (argv) {
   const configFile = argv.deployerConfig;
-  configFile[argv.key] = argv.value;
+  const matchingConfigFileKey = convertInputToDeployerConfigKey(argv.key);
+
+  configFile[matchingConfigFileKey] = argv.value;
   fs.writeFileSync(deployerConfigFilePath, JSON.stringify(configFile));
   logger.info(
     `${formatter.success(
-      `Config key ${formatter.info(argv.key)} has been successfully set to ${formatter.info(
-        argv.value
-      )}.`
+      `Config key ${formatter.info(
+        matchingConfigFileKey
+      )} has been successfully set to ${formatter.info(argv.value)}.`
     )}`
   );
 };

--- a/bin/cmds/config_cmds/set.js
+++ b/bin/cmds/config_cmds/set.js
@@ -15,7 +15,7 @@ exports.builder = (yargs) => {
     const key = convertInputToDeployerConfigKey(argv.key);
 
     //Coerce user input to correct config
-    switch (key.toLowerCase()) {
+    switch (key) {
       case "name":
         var validCharset = /^[a-zA-Z0-9-]+$/;
         if (!validCharset.test(argv.value)) {
@@ -25,10 +25,10 @@ exports.builder = (yargs) => {
         }
         argv.value = argv.value.toLowerCase();
         break;
-      case "loglevel":
+      case "logLevel":
         argv.value = convertInputToLogLevel(argv.value);
         break;
-      case "checkforupdates":
+      case "checkForUpdates":
         argv.value = convertInputToBoolean(argv.value);
         break;
     }

--- a/bin/cmds/config_cmds/unset.js
+++ b/bin/cmds/config_cmds/unset.js
@@ -1,30 +1,27 @@
 const { logger, formatter } = require("../../utils/textUtils");
 const fs = require("fs");
-const defaultConfig = require("../../res/defaultConfig.json");
-const { deployerConfigFilePath } = require("../../utils/configUtils");
+const { deployerConfigFilePath, defaultConfig } = require("../../utils/configUtils");
+const { convertInputToDeployerConfigKey } = require("../../utils/inputUtils");
 
 exports.command = "unset <key>";
 exports.desc = "Reverts the key to its default value.";
 exports.builder = (yargs) => {
   yargs.check((argv) => {
-    const acceptableKeys = Object.keys(defaultConfig);
-    if (!acceptableKeys.includes(argv.key)) {
-      throw new Error(
-        formatter.error(
-          `Key ${argv.key} is not supported. Acceptable keys are:\n${acceptableKeys.join(", ")}`
-        )
-      );
-    }
+    convertInputToDeployerConfigKey(argv.key);
     return true;
   });
 };
 exports.handler = function (argv) {
   const configFile = argv.deployerConfig;
-  configFile[argv.key] = defaultConfig[argv.key];
+  const matchingConfigFileKey = convertInputToDeployerConfigKey(argv.key);
+
+  configFile[matchingConfigFileKey] = defaultConfig[matchingConfigFileKey];
   fs.writeFileSync(deployerConfigFilePath, JSON.stringify(configFile));
   logger.info(
     formatter.success(
-      `Config key ${formatter.info(argv.key)} has been successfully reverted to default.`
+      `Config key ${formatter.info(
+        matchingConfigFileKey
+      )} has been successfully reverted to ${formatter.info(defaultConfig[matchingConfigFileKey])}.`
     )
   );
 };

--- a/bin/cmds/up.js
+++ b/bin/cmds/up.js
@@ -69,11 +69,14 @@ exports.handler = async function (argv) {
       args = [`up`, `${argv.host}`, `${s}`, `-f`, `${argv.file}`];
       if (argv.q) {
         args.push(`-q`);
+        args.push(argv["q"]);
       }
       if (argv.l) {
         args.push("-l");
         args.push(argv["l"]);
       }
+      args.push(`--check-updates`);
+      args.push("false");
       const worker = spawnWorker(`deployer`, args, s);
       workers.push(worker);
     });

--- a/bin/res/defaultConfig.json
+++ b/bin/res/defaultConfig.json
@@ -1,4 +1,5 @@
 {
   "name": "deployer",
-  "loglevel": "INFO"
+  "loglevel": "INFO",
+  "checkForUpdates": true
 }

--- a/bin/res/defaultConfig.json
+++ b/bin/res/defaultConfig.json
@@ -1,5 +1,5 @@
 {
   "name": "deployer",
-  "loglevel": "INFO",
+  "logLevel": "INFO",
   "checkForUpdates": true
 }

--- a/bin/services/deploy.js
+++ b/bin/services/deploy.js
@@ -110,7 +110,7 @@ function buildStage(build, targetCWD = undefined) {
     shell.pushd("-q", targetCWD);
   }
 
-  const buildResult = shell.exec(build, { silent: logger.isLevelSilent(logger.loglevels.INFO) });
+  const buildResult = shell.exec(build, { silent: logger.isLevelSilent(logger.logLevels.INFO) });
   if (buildResult.code !== 0) {
     throw new Error("Failed to build the image using the command provided in the config.");
   }
@@ -190,7 +190,7 @@ async function pullAndTagStage(imageName, sshHost, destPort, tagName) {
   shell.exec(
     `docker -H ssh://${sshHost} image tag localhost:${destPort}/${imageName} ${tagName}/${imageName}:latest`,
     {
-      silent: logger.isLevelSilent(logger.loglevels.INFO),
+      silent: logger.isLevelSilent(logger.logLevels.INFO),
     }
   );
   logger.info(formatter.success(`Tag completed.`));

--- a/bin/services/middleware/checkForUpdatesMiddleware.js
+++ b/bin/services/middleware/checkForUpdatesMiddleware.js
@@ -149,9 +149,13 @@ function isUpdateRequired({ localVersion, remoteVersion }) {
  * at install directory and fetching the lastest deployer version from remote deployer repositry and asserting whether
  * an upgrade is required. If an update is required a message will be printed.
  *
+ * @param {Object} argv - Argv object supplied from yargs
  * @returns {Promise<void>} An awaitable promise when the check for updates is done.
  */
-async function checkForUpdatesMiddleware() {
+async function checkForUpdatesMiddleware(argv) {
+  if (!argv.deployerConfig.checkForUpdates) {
+    return;
+  }
   let remotePackageJson;
   try {
     remotePackageJson = await getRemotePackageJson();

--- a/bin/services/middleware/checkForUpdatesMiddleware.js
+++ b/bin/services/middleware/checkForUpdatesMiddleware.js
@@ -153,9 +153,18 @@ function isUpdateRequired({ localVersion, remoteVersion }) {
  * @returns {Promise<void>} An awaitable promise when the check for updates is done.
  */
 async function checkForUpdatesMiddleware(argv) {
-  if (!argv.deployerConfig.checkForUpdates) {
-    return;
+  //flag should overwrite global config
+  if (typeof argv.checkUpdates === "boolean") {
+    if (!argv.checkUpdates) {
+      return;
+    }
+  } else {
+    if (!argv.deployerConfig.checkForUpdates) {
+      return;
+    }
   }
+
+  logger.fatal(formatter.warning("CHECK"));
   let remotePackageJson;
   try {
     remotePackageJson = await getRemotePackageJson();

--- a/bin/services/middleware/loadDeployerConfigMiddleware.js
+++ b/bin/services/middleware/loadDeployerConfigMiddleware.js
@@ -52,7 +52,16 @@ function loadDeployerConfigMiddleware(argv) {
         configKeysMissing = true;
       }
     });
-    if (configKeysMissing) {
+
+    //Find extra keys in deployerConfig and remove them
+    let extraConfigKeys = false;
+    Object.keys(deployerConfig).forEach((key) => {
+      if (!Object.keys(defaultDeployerConfig).includes(key)) {
+        deployerConfig[key] = undefined;
+        extraConfigKeys = true;
+      }
+    });
+    if (configKeysMissing || extraConfigKeys) {
       fs.writeFileSync(deployerConfigFilePath, JSON.stringify(deployerConfig));
     }
 

--- a/bin/services/middleware/setLogLevelMiddleware.js
+++ b/bin/services/middleware/setLogLevelMiddleware.js
@@ -2,11 +2,11 @@ const { logger } = require("../../utils/textUtils");
 
 function setLogLevelMiddleware(argv) {
   if (argv.l) {
-    process.env.LOG_LEVEL = logger.loglevels[argv.l.toUpperCase()];
+    process.env.LOG_LEVEL = logger.logLevels[argv.l.toUpperCase()];
   } else if (argv.quiet) {
     process.env.LOG_LEVEL = 1;
   } else {
-    process.env.LOG_LEVEL = logger.loglevels[argv.deployerConfig.loglevel];
+    process.env.LOG_LEVEL = logger.logLevels[argv.deployerConfig.logLevel];
   }
 }
 

--- a/bin/services/registry.js
+++ b/bin/services/registry.js
@@ -15,7 +15,7 @@ function runRegistry(port) {
     logger.fatal(formatter.error("Failed to run local registry."));
     exit(1);
   }
-  logger.info(formatter.success(`Registry listening at port ${formatter.info(port)} ...`));
+  logger.info(formatter.success(`Registry listening at port ${formatter.info(port)}...`));
 }
 
 /**
@@ -33,7 +33,7 @@ function stopRegistry() {
     logger.fatal(formatter.error("Failed to remove local registry container."));
     exit(1);
   }
-  logger.info(formatter.success("Local registry stopped succesffully ..."));
+  logger.info(formatter.success("Local registry stopped successfully..."));
 }
 
 module.exports = { runRegistry, stopRegistry };

--- a/bin/utils/configUtils.js
+++ b/bin/utils/configUtils.js
@@ -1,6 +1,7 @@
 const os = require("os");
 const path = require("path");
 const packageJson = require("../../package.json");
+const defaultConfig = require("../res/defaultConfig.json");
 
 const deployerDirectory = path.resolve(os.homedir(), ".deployer");
 const configFileName = "config.json";
@@ -11,4 +12,5 @@ module.exports = {
   configFileName,
   deployerConfigFilePath,
   deployerVersion: packageJson.version,
+  defaultConfig,
 };

--- a/bin/utils/dockerUtils.js
+++ b/bin/utils/dockerUtils.js
@@ -1,5 +1,4 @@
 const shell = require("shelljs");
-const logger = require("./textUtils/logger");
 
 /**
  * @description Gets the port on which the deployer doker registry is running.

--- a/bin/utils/inputUtils.js
+++ b/bin/utils/inputUtils.js
@@ -24,25 +24,25 @@ function convertInputToBoolean(input) {
  * @description Receives <input> and converts it to log level key.
  *
  * @param {*} input - Input as received in argv.
- * @returns {string} Log level key from logger.loglevels.
+ * @returns {string} Log level key from logger.logLevels.
  * @throws When input cannot be parsed to log level.
  */
 function convertInputToLogLevel(input) {
-  //if loglevel is given as a number, clamp it to accepted range and match correct loglevel name
+  //if logLevel is given as a number, clamp it to accepted range and match correct logLevel name
   if (typeof input === "number") {
-    if (input < logger.loglevels.OFF) {
-      return logger.loglevels.OFF;
-    } else if (input > logger.loglevels.ALL) {
-      return logger.loglevels.ALL;
+    if (input < logger.logLevels.OFF) {
+      return logger.logLevels.OFF;
+    } else if (input > logger.logLevels.ALL) {
+      return logger.logLevels.ALL;
     }
-    return Object.keys(logger.loglevels).find((level) => logger.loglevels[level] === input);
+    return Object.keys(logger.logLevels).find((level) => logger.logLevels[level] === input);
   }
-  //if loglevel is given as a name, format it correclty to check if it is a valid loglevel name
+  //if logLevel is given as a name, format it correclty to check if it is a valid logLevel name
   else {
-    if (!Object.keys(logger.loglevels).includes(input.toString().toUpperCase())) {
+    if (!Object.keys(logger.logLevels).includes(input.toString().toUpperCase())) {
       throw new Error(
         `Log level can only be between 0-7 or one of the option: ${Object.keys(
-          logger.loglevels
+          logger.logLevels
         ).join(", ")}.`
       );
     } else {

--- a/bin/utils/inputUtils.js
+++ b/bin/utils/inputUtils.js
@@ -1,0 +1,73 @@
+const { defaultConfig } = require("./configUtils");
+const { logger } = require("./textUtils");
+
+/**
+ * @description Receives <input> and converts it to boolean.
+ *
+ * @param {*} input - Input as received in argv.
+ * @returns {boolean} As parsed from argv.
+ * @throws When input cannot be parsed to boolean.
+ */
+function convertInputToBoolean(input) {
+  if (typeof input === "number") {
+    return Boolean(input);
+  } else {
+    if (["true", "false"].includes(input)) {
+      return input === "true";
+    } else {
+      throw new Error(`Invalid input "${input}", failed to parse to boolean.`);
+    }
+  }
+}
+
+/**
+ * @description Receives <input> and converts it to log level key.
+ *
+ * @param {*} input - Input as received in argv.
+ * @returns {string} Log level key from logger.loglevels.
+ * @throws When input cannot be parsed to log level.
+ */
+function convertInputToLogLevel(input) {
+  //if loglevel is given as a number, clamp it to accepted range and match correct loglevel name
+  if (typeof input === "number") {
+    if (input < logger.loglevels.OFF) {
+      return logger.loglevels.OFF;
+    } else if (input > logger.loglevels.ALL) {
+      return logger.loglevels.ALL;
+    }
+    return Object.keys(logger.loglevels).find((level) => logger.loglevels[level] === input);
+  }
+  //if loglevel is given as a name, format it correclty to check if it is a valid loglevel name
+  else {
+    if (!Object.keys(logger.loglevels).includes(input.toString().toUpperCase())) {
+      throw new Error(
+        `Log level can only be between 0-7 or one of the option: ${Object.keys(
+          logger.loglevels
+        ).join(", ")}.`
+      );
+    } else {
+      return input.toString().toUpperCase();
+    }
+  }
+}
+
+/**
+ * @description Receives <input> and converts it to deployer config key.
+ *
+ * @param {*} input - Input as received in argv.
+ * @returns {string} Matching config key as present in default config.
+ * @throws When input cannot be parsed to deployer config key.
+ */
+function convertInputToDeployerConfigKey(input) {
+  const key = Object.keys(defaultConfig).find(
+    (element) => element.toLowerCase() === input.toLowerCase()
+  );
+  if (!key) {
+    throw new Error(
+      `Key ${input} is not supported. Accepted keys are:\n${Object.keys(defaultConfig).join(", ")}`
+    );
+  }
+  return key;
+}
+
+module.exports = { convertInputToBoolean, convertInputToLogLevel, convertInputToDeployerConfigKey };

--- a/bin/utils/textUtils/logger.js
+++ b/bin/utils/textUtils/logger.js
@@ -24,7 +24,7 @@ function isLevelSilent(loglevel) {
  * @returns {boolean} True if the loglevel of the command is loglevels.DEBUG (5) or higher.
  */
 function isDebugMode() {
-  return !isLevelSilent(loglevels.DEBUG);
+  return !isLevelSilent(loglevels.ALL);
 }
 
 /**

--- a/bin/utils/textUtils/logger.js
+++ b/bin/utils/textUtils/logger.js
@@ -2,44 +2,44 @@ const util = require("util");
 const formatter = require("./formatter");
 
 /**
- * Enum for loglevel values.
+ * Enum for logLevel values.
  * @enum {number}
  */
-var loglevels = { OFF: 0, FATAL: 1, ERROR: 2, WARN: 3, INFO: 4, DEBUG: 5, TRACE: 6, ALL: 7 };
+var logLevels = { OFF: 0, FATAL: 1, ERROR: 2, WARN: 3, INFO: 4, DEBUG: 5, TRACE: 6, ALL: 7 };
 
 /**
- * @description Asserts whether given loglevel should or should not log.
- * @param {loglevels} loglevel - The loglevel to assert whether it should be logging or not.
+ * @description Asserts whether given logLevel should or should not log.
+ * @param {logLevels} logLevel - The logLevel to assert whether it should be logging or not.
  * @returns true if given log level should not log.
  */
-function isLevelSilent(loglevel) {
+function isLevelSilent(logLevel) {
   if (!process.env.LOG_LEVEL) {
-    return loglevels.FATAL < loglevel;
+    return logLevels.FATAL < logLevel;
   }
-  return process.env.LOG_LEVEL < loglevel;
+  return process.env.LOG_LEVEL < logLevel;
 }
 
 /**
  * @description Asserts whether the command is running in debug mode or not.
- * @returns {boolean} True if the loglevel of the command is loglevels.DEBUG (5) or higher.
+ * @returns {boolean} True if the logLevel of the command is logLevels.DEBUG (5) or higher.
  */
 function isDebugMode() {
-  return !isLevelSilent(loglevels.ALL);
+  return !isLevelSilent(logLevels.ALL);
 }
 
 /**
- * @description Takes a list of strings and logs them using the <printFunc> if the <loglevel> provided is not silenced.
- *              For flags higher or equal to loglevels.DEBUG (5) additional formatting is added.
+ * @description Takes a list of strings and logs them using the <printFunc> if the <logLevel> provided is not silenced.
+ *              For flags higher or equal to logLevels.DEBUG (5) additional formatting is added.
  * @param {Array<string>} textList - The array of strings to be logged
- * @param {loglevels} loglevel - The loglevel at which the text should be printed.
+ * @param {logLevels} logLevel - The logLevel at which the text should be printed.
  * @param {(string)=>void} printFunc
  */
-function log(textList, loglevel, printFunc) {
-  if (!isLevelSilent(loglevel)) {
+function log(textList, logLevel, printFunc) {
+  if (!isLevelSilent(logLevel)) {
     if (isDebugMode()) {
       printFunc(
         formatter.debug(
-          `[${Object.keys(loglevels).find((level) => loglevels[level] === loglevel)}]`
+          `[${Object.keys(logLevels).find((level) => logLevels[level] === logLevel)}]`
         )
       );
     }
@@ -55,7 +55,7 @@ function log(textList, loglevel, printFunc) {
  * @param {Array<string>} textList - Text to be logged.
  */
 function fatal(...textList) {
-  log(textList, loglevels.FATAL, console.error);
+  log(textList, logLevels.FATAL, console.error);
 }
 
 /**
@@ -63,7 +63,7 @@ function fatal(...textList) {
  * @param {Array<string>} textList - Text to be logged.
  */
 function error(...textList) {
-  log(textList, loglevels.ERROR, console.error);
+  log(textList, logLevels.ERROR, console.error);
 }
 
 /**
@@ -71,7 +71,7 @@ function error(...textList) {
  * @param {Array<string>} textList - Text to be logged.
  */
 function warn(...textList) {
-  log(textList, loglevels.WARN, console.error);
+  log(textList, logLevels.WARN, console.error);
 }
 
 /**
@@ -79,7 +79,7 @@ function warn(...textList) {
  * @param {Array<string>} textList - Text to be logged.
  */
 function info(...textList) {
-  log(textList, loglevels.INFO, console.log);
+  log(textList, logLevels.INFO, console.log);
 }
 
 /**
@@ -87,7 +87,7 @@ function info(...textList) {
  * @param {Array<string>} textList - Text to be logged.
  */
 function debug(...textList) {
-  log(textList, loglevels.DEBUG, console.log);
+  log(textList, logLevels.DEBUG, console.log);
 }
 
 /**
@@ -95,7 +95,7 @@ function debug(...textList) {
  * @param {Array<string>} textList - Text to be logged.
  */
 function trace(...textList) {
-  log(textList, loglevels.TRACE, console.log);
+  log(textList, logLevels.TRACE, console.log);
 }
 
 const logger = {
@@ -106,7 +106,7 @@ const logger = {
   debug,
   trace,
   isLevelSilent,
-  loglevels,
+  logLevels,
 };
 
 module.exports = logger;

--- a/bin/utils/workerUtils.js
+++ b/bin/utils/workerUtils.js
@@ -36,7 +36,7 @@ function spawnWorker(command, args, name = "Cross-Spawn ChildProcess") {
  */
 async function awaitableSpawnProcess(command, args) {
   const worker = require("child_process").spawn(command, args, {
-    stdio: logger.isLevelSilent(logger.loglevels.INFO) ? "ignore" : "inherit",
+    stdio: logger.isLevelSilent(logger.logLevels.INFO) ? "ignore" : "inherit",
   });
   const exitCode = await new Promise((resolve, reject) => {
     worker.on("exit", (code) => {

--- a/command.js
+++ b/command.js
@@ -63,22 +63,31 @@ yargs
   .group(["q", "l", "help", "version"], "Global options:")
   .fail((msg, e, yargs) => {
     /* 
-      Yargs does not consistently put the error message into <msg> so we have to extract it from the error ourselves
-      `e` will look like this:  
-          
-      Error: <ERROR_MESSAGE>
-        stacktrace line 1
-        stacktrace line 2
+        Yargs does not consistently put the error message into <msg>. When that happens, we have to extract it from the error ourselves
+        `e` will look like this:  
+            
+        Error: <ERROR_MESSAGE>
+          stacktrace line 1
+          stacktrace line 2
+  
+        e.toString() returns "Error: <ERROR_MESSAGE>"
+      */
 
-      e.toString() returns "Error: <ERROR_MESSAGE>"
-    */
-    const errorMessage = /Error: (.*)/g.exec(e.toString())[1];
-
-    logger.fatal(formatter.error(errorMessage));
-    logger.debug(e);
-    logger.info(
-      "\nFor help with the command run it with the `--help` flag, or visit the documentation."
-    );
+    if (msg) {
+      const errorMessage = msg;
+      logger.fatal(formatter.error(errorMessage));
+      logger.debug(e);
+      yargs.showHelp();
+    } else if (e) {
+      const errorMessage = /Error: (.*)/g.exec(e.toString())[1];
+      logger.fatal(formatter.error(errorMessage));
+      logger.debug(e);
+      logger.info(
+        "\nFor help with the command run it with the `--help` flag, or visit the documentation."
+      );
+    } else {
+      yargs.showHelp();
+    }
     exit(1);
   })
   .wrap(90).argv;

--- a/command.js
+++ b/command.js
@@ -30,6 +30,10 @@ yargs
       }
     },
   })
+  .option("check-updates", {
+    describe: "Sets whether the command should check for updates before executing.",
+    type: "boolean",
+  })
   .middleware([
     (argv, yargs) => {
       loadDeployerConfigMiddleware(argv);
@@ -44,7 +48,7 @@ yargs
   .demandCommand()
   .commandDir("bin/cmds")
   .help()
-  .group(["q", "l", "help", "version"], "Global options:")
+  .group(["q", "l", "help", "version", "check-updates"], "Global options:")
   .fail((msg, e, yargs) => {
     /* 
         Yargs does not consistently put the error message into <msg>. When that happens, we have to extract it from the error ourselves

--- a/command.js
+++ b/command.js
@@ -5,7 +5,7 @@ const {
   checkForUpdatesMiddleware,
   loadDeployerConfigMiddleware,
 } = require("./bin/services/middleware");
-const setloglevelMiddleware = require("./bin/services/middleware/setloglevelMiddleware");
+const setLogLevelMiddleware = require("./bin/services/middleware/setLogLevelMiddleware");
 const { convertInputToLogLevel } = require("./bin/utils/inputUtils");
 const { logger, formatter } = require("./bin/utils/textUtils");
 
@@ -23,7 +23,7 @@ yargs
     alias: "log-level",
     describe:
       "Sets the log-level to provided level. Accepts numerical value between 0-7 or one of the choices.",
-    choices: Object.keys(logger.loglevels),
+    choices: Object.keys(logger.logLevels),
     coerce: (value) => {
       if (value) {
         return convertInputToLogLevel(value);
@@ -35,7 +35,7 @@ yargs
       loadDeployerConfigMiddleware(argv);
     },
     (argv, yargs) => {
-      setloglevelMiddleware(argv);
+      setLogLevelMiddleware(argv);
     },
     async (argv, yargs) => {
       await checkForUpdatesMiddleware(argv);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "deployer",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "deployer",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deployer",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Builds specified docker image and deploys to remote host.",
   "repository": "https://github.com/backslashbuild/deployer",
   "main": "command.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deployer",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "Builds specified docker image and deploys to remote host.",
   "repository": "https://github.com/backslashbuild/deployer",
   "main": "command.js",

--- a/patch-notes.yml
+++ b/patch-notes.yml
@@ -70,7 +70,7 @@
     - note: Upon deploying using `deployer up` a label is added to the targetted service containing deployment metadata.
     - note: Adds `inspect` CLI. This command fetches the metadata stored in the services and logs them.
 2.3.0:
-  date: 06-09-2021
+  date: 10-09-2021
   notes: 
   - note: "Feature: Adds `checkForUpdates` key in global config."
     children: 

--- a/patch-notes.yml
+++ b/patch-notes.yml
@@ -69,10 +69,6 @@
   notes: 
     - note: Upon deploying using `deployer up` a label is added to the targetted service containing deployment metadata.
     - note: Adds `inspect` CLI. This command fetches the metadata stored in the services and logs them.
-2.2.1:
-  date: 06-09-2021
-  notes: 
-    - note: Bugfix around error reporting from yargs.
 2.3.0:
   date: 06-09-2021
   notes: 
@@ -81,9 +77,10 @@
     - note: Flag to choose whether deployer should check for updates.
     - note: Can be set to `true` or `false` using `deploy config set checkForUpdates true`.
     - note: Defaults to true.
+  - note: "Fix around error reporting from yargs."
   - note: "Fix: Multi-line exception messages to be logged properly."
   - note: "Fix: `-l` flag not working as expected when deploying multiple services."
   - note: "Fix: Keys in global deployer config that do not exist in default config are deleted."
   - note: "Style: Improve the way errors are logged during `up`."
-  - note: "Refactor: `loglevel` config key changed to `logLevel`." 
+  - note: "Refactor: `loglevel` config key changed to `logLevel`."
     

--- a/patch-notes.yml
+++ b/patch-notes.yml
@@ -77,8 +77,10 @@
     - note: Flag to choose whether deployer should check for updates.
     - note: Can be set to `true` or `false` using `deploy config set checkForUpdates true`.
     - note: Defaults to true.
+  - note: "Feature: Adds `--check-updates` global option. If set, overwrites the checkForUpdates global config value."
   - note: "Fix: around error reporting from yargs."
   - note: "Fix: Multi-line exception messages to be logged properly."
   - note: "Fix: `-l` flag not working as expected when deploying multiple services."
   - note: "Fix: Keys in global deployer config that do not exist in default config are deleted."
+  - note: "Fix: Deploying multiple images in parallel using `up` command no longer prints update message multiple times."
     

--- a/patch-notes.yml
+++ b/patch-notes.yml
@@ -83,5 +83,7 @@
     - note: Defaults to true.
   - note: "Fix: Multi-line exception messages to be logged properly."
   - note: "Fix: `-l` flag not working as expected when deploying multiple services."
-  - note: "Style: Improve the way errors are logged during `up`"
+  - note: "Fix: Keys in global deployer config that do not exist in default config are deleted."
+  - note: "Style: Improve the way errors are logged during `up`."
+  - note: "Refactor: `loglevel` config key changed to `logLevel`." 
     

--- a/patch-notes.yml
+++ b/patch-notes.yml
@@ -73,4 +73,15 @@
   date: 06-09-2021
   notes: 
     - note: Bugfix around error reporting from yargs.
+2.3.0:
+  date: 06-09-2021
+  notes: 
+  - note: "Feature: Adds `checkForUpdates` key in global config."
+    children: 
+    - note: Flag to choose whether deployer should check for updates.
+    - note: Can be set to `true` or `false` using `deploy config set checkForUpdates true`.
+    - note: Defaults to true.
+  - note: "Fix: Multi-line exception messages to be logged properly."
+  - note: "Fix: `-l` flag not working as expected when deploying multiple services."
+  - note: "Style: Improve the way errors are logged during `up`"
     

--- a/patch-notes.yml
+++ b/patch-notes.yml
@@ -69,3 +69,8 @@
   notes: 
     - note: Upon deploying using `deployer up` a label is added to the targetted service containing deployment metadata.
     - note: Adds `inspect` CLI. This command fetches the metadata stored in the services and logs them.
+2.2.1:
+  date: 06-09-2021
+  notes: 
+    - note: Bugfix around error reporting from yargs.
+    

--- a/patch-notes.yml
+++ b/patch-notes.yml
@@ -77,10 +77,8 @@
     - note: Flag to choose whether deployer should check for updates.
     - note: Can be set to `true` or `false` using `deploy config set checkForUpdates true`.
     - note: Defaults to true.
-  - note: "Fix around error reporting from yargs."
+  - note: "Fix: around error reporting from yargs."
   - note: "Fix: Multi-line exception messages to be logged properly."
   - note: "Fix: `-l` flag not working as expected when deploying multiple services."
   - note: "Fix: Keys in global deployer config that do not exist in default config are deleted."
-  - note: "Style: Improve the way errors are logged during `up`."
-  - note: "Refactor: `loglevel` config key changed to `logLevel`."
     


### PR DESCRIPTION
# v2.3.0

## Features:
- feat(config): Add `checkForUpdates` key.
- feat: Add `--check-updates` global option.

## Fixes:
- fix(error-handling): Unhandled exception on yargs.fail.
- fix(error-handling): Multi-line exception messages logged correctly.
- fix: `-l` flag not working for multi-deploy.
- fix: Multi-deploy printing the update notification multiple times.

## Refactor:
- refactor(config): `loglevel` key changed to `logLevel`.
- refactor: User input checks for arguments and options.

## Style:
- style: Improve logging during `up` command.

## Documentation:
- docs: Description of checkForUpdates on README.
- docs: Description of `--check-updates` global option.
- docs: Merge unreleased v.2.2.1 patchnotes to v2.3.0.